### PR TITLE
Add #count method on record objects.

### DIFF
--- a/lib/frozen_record/base.rb
+++ b/lib/frozen_record/base.rb
@@ -61,6 +61,10 @@ module FrozenRecord
         end
       end
 
+      def count
+        load_records.size
+      end
+
       private
 
       def store

--- a/spec/frozen_record_spec.rb
+++ b/spec/frozen_record_spec.rb
@@ -45,7 +45,7 @@ describe FrozenRecord::Base do
       expect(attributes).to be == {
         'id' => 1,
         'name' => 'Canada',
-        'capital' => 'Ottawa', 
+        'capital' => 'Ottawa',
         'density' => 3.5,
         'population' => 33.88,
         'founded_on' => Date.parse('1867-07-01'),
@@ -97,4 +97,15 @@ describe FrozenRecord::Base do
 
   end
 
+  describe '#count' do
+
+    it 'can count objects with no records' do
+      expect(Car.count).to be 0
+    end
+
+    it 'can count objects with records' do
+      expect(Country.count).to be 3
+    end
+
+  end
 end


### PR DESCRIPTION
I was doing something in Shopify and I realized that was missing. What do you think?
