### PR TITLE
Fix deprecation warnings in tests

### DIFF
--- a/lib/frozen_record/base.rb
+++ b/lib/frozen_record/base.rb
@@ -51,7 +51,7 @@ module FrozenRecord
                :minimum, :maximum, :average, :sum, to: :current_scope
 
       def file_path
-        raise "You must define `#{name}.base_path`" unless base_path
+        fail ArgumentError, "You must define `#{name}.base_path`" unless base_path
         File.join(base_path, "#{name.underscore.pluralize}.yml")
       end
 

--- a/spec/frozen_record_spec.rb
+++ b/spec/frozen_record_spec.rb
@@ -5,10 +5,10 @@ describe FrozenRecord::Base do
   describe '.base_path' do
 
     it 'raise a RuntimeError  on first query attempt if not set' do
-      Country.stub(:base_path).and_return(nil)
+      allow(Country).to receive_message_chain(:base_path).and_return(nil)
       expect {
         Country.file_path
-      }.to raise_error
+      }.to raise_error(ArgumentError)
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@ FrozenRecord::Base.base_path = File.join(File.dirname(__FILE__), 'fixtures')
 Dir[File.expand_path(File.join(File.dirname(__FILE__), 'support', '**', '*.rb'))].each { |f| require f }
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
This fixes multiple deprecation warnings in test.

```
WARNING: Using the `raise_error` matcher without providing a specific
error or message risks false positives, since `raise_error` will match
when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`,
potentially allowing the expectation to pass without even executing the
method you are intending to call. Instead consider providing a specific
error class or message. This message can be supressed by setting:
`RSpec::Expectations.configuration.warn_about_potential_false_positives
= false`.
```

```
RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values=
is deprecated, it is now set to true as default and setting it to false
has no effect.
```

```
Using `stub` from rspec-mocks' old `:should` syntax without explicitly
enabling the syntax is deprecated. Use the new `:expect` syntax or
explicitly enable `:should` instead. Called from
/Users/tero/Code/ttasanen-frozen_record/spec/frozen_record_spec.rb:8:in
`block (3 levels) in <top (required)>'.
```