### PR TITLE
add support for erb in frozen record yml files

### DIFF
--- a/lib/frozen_record/base.rb
+++ b/lib/frozen_record/base.rb
@@ -85,7 +85,10 @@ module FrozenRecord
 
       def load_records
         @records ||= begin
-          records = YAML.load_file(file_path) || []
+          yml_erb_data = File.read(file_path)
+          yml_data = ERB.new(yml_erb_data).result
+
+          records = YAML.load(yml_data) || []
           define_attributes!(list_attributes(records))
           records.map(&method(:new)).freeze
         end

--- a/spec/fixtures/countries.yml
+++ b/spec/fixtures/countries.yml
@@ -1,7 +1,7 @@
 ---
 - id: 1
   name: Canada
-  capital: Ottawa
+  capital: <%= 'Ottawa' %>
   density: 3.5
   population: 33.88
   founded_on: 1867-07-01
@@ -11,7 +11,7 @@
 
 - id: 2
   name: France
-  capital: Paris
+  capital: <%= 'Paris' %>
   density: 116
   population: 65.7
   founded_on: 486-01-01
@@ -19,7 +19,7 @@
 
 - id: 3
   name: Austria
-  capital: Vienna
+  capital: <%= 'Vienna' %>
   density: 100.3
   population: 8.462
   founded_on: 1156-01-01

--- a/spec/frozen_record_spec.rb
+++ b/spec/frozen_record_spec.rb
@@ -13,6 +13,15 @@ describe FrozenRecord::Base do
 
   end
 
+  describe '#load_records' do
+
+    it 'processes erb' do
+      country = Country.first
+      expect(country.capital).to be == 'Ottawa'
+    end
+
+  end
+
   describe '#==' do
 
     it 'returns true if both instances are from the same class and have the same id' do


### PR DESCRIPTION
Adds support for pre-processing the yml file using ERB. 

This is consistent with the way Rails already treats many yml files. I have a specific use case that would benefit from this where I have frozen records with json templates and I'd prefer to store the json in individual files and keep my yml file easier to work with. Thus I need to read files using ruby in my frozen record yml file.

@byroot 