### PR TITLE
Assert sum within a delta

### DIFF
--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -349,7 +349,7 @@ describe 'querying' do
 
     it 'returns the sum of the column argument' do
       sum = Country.sum(:population)
-      expect(sum).to be == 108.04200000000002
+      expect(sum).to be_within(0.00000000000002).of(108.042)
     end
 
   end


### PR DESCRIPTION
https://github.com/byroot/frozen_record/pull/18 has a broken test. It looks like Ruby 2.4 fixed a precision bug when summing floats, so I'm fixing the test.

We just have to remember to remove the delta once we no longer care about other versions of Ruby.

cc @davidcornu
