### PR TITLE
Don't raise on eager_load! when auto_reloading is true

### DIFF
--- a/lib/frozen_record/base.rb
+++ b/lib/frozen_record/base.rb
@@ -79,11 +79,7 @@ module FrozenRecord
       end
 
       def eager_load!
-        if auto_reloading
-          raise RuntimeError, "There is no point eager loading a FrozenRecord if auto_reloading is enabled!"
-        end
-
-        return if abstract_class?
+        return if auto_reloading || abstract_class?
 
         load_records
       end


### PR DESCRIPTION
This changes the behaviour of eager_load! to no-op if auto_reloading is true. This allows for an exception-free eager_loading experience in development mode if you ever eager_load all of your namespaces.