### PR TITLE
Introduce FrozenRecord::TestHelper.load_fixture and .unload_fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor

--- a/lib/frozen_record/test_helper.rb
+++ b/lib/frozen_record/test_helper.rb
@@ -1,0 +1,35 @@
+module FrozenRecord
+  module TestHelper
+    def self.load_fixture(model_class, alternate_base_path)
+      @cache ||= {}
+
+      ensure_model_class_is_frozenrecord(model_class)
+
+      @cache[model_class] = {
+        old_base_path: model_class.base_path,
+        old_auto_reloading: model_class.auto_reloading,
+      }
+
+      model_class.auto_reloading = true
+      model_class.base_path = alternate_base_path
+    end
+
+    def self.unload_fixtures
+      @cache.each do |model_class, cached_values|
+        ensure_model_class_is_frozenrecord(model_class)
+
+        model_class.base_path = cached_values[:old_base_path]
+        model_class.load_records
+        model_class.auto_reloading = cached_values[:old_auto_reloading]
+      end
+    end
+
+    private
+
+    def self.ensure_model_class_is_frozenrecord(model_class)
+      return if model_class < FrozenRecord::Base
+      raise ArgumentError, "Model class (#{model_class}) does not inherit from #{FrozenRecord::Base}"
+    end
+    private_class_method :ensure_model_class_is_frozenrecord
+  end
+end

--- a/lib/frozen_record/test_helper.rb
+++ b/lib/frozen_record/test_helper.rb
@@ -1,5 +1,7 @@
 module FrozenRecord
   module TestHelper
+    NoFixturesLoaded = Class.new(StandardError)
+
     def self.load_fixture(model_class, alternate_base_path)
       @cache ||= {}
 
@@ -15,6 +17,10 @@ module FrozenRecord
     end
 
     def self.unload_fixtures
+      if !defined?(@cache) || !@cache.present?
+        raise NoFixturesLoaded, "`unload_fixtures` was called before any calls to `load_fixture`"
+      end
+
       @cache.each do |model_class, cached_values|
         ensure_model_class_is_frozenrecord(model_class)
 
@@ -22,6 +28,8 @@ module FrozenRecord
         model_class.load_records
         model_class.auto_reloading = cached_values[:old_auto_reloading]
       end
+
+      @cache = nil
     end
 
     private

--- a/lib/frozen_record/test_helper.rb
+++ b/lib/frozen_record/test_helper.rb
@@ -2,40 +2,39 @@ module FrozenRecord
   module TestHelper
     NoFixturesLoaded = Class.new(StandardError)
 
-    def self.load_fixture(model_class, alternate_base_path)
-      @cache ||= {}
+    class << self
+      def load_fixture(model_class, alternate_base_path)
+        @cache ||= {}
 
-      ensure_model_class_is_frozenrecord(model_class)
-
-      @cache[model_class] = {
-        old_base_path: model_class.base_path,
-        old_auto_reloading: model_class.auto_reloading,
-      }
-
-      model_class.auto_reloading = true
-      model_class.base_path = alternate_base_path
-    end
-
-    def self.unload_fixtures
-      if !defined?(@cache) || !@cache.present?
-        raise NoFixturesLoaded, "`unload_fixtures` was called before any calls to `load_fixture`"
-      end
-
-      @cache.each do |model_class, cached_values|
         ensure_model_class_is_frozenrecord(model_class)
 
-        model_class.base_path = cached_values[:old_base_path]
-        model_class.load_records
-        model_class.auto_reloading = cached_values[:old_auto_reloading]
+        return if @cache.key?(model_class)
+
+        @cache[model_class] = {
+          old_base_path: model_class.base_path,
+          old_auto_reloading: model_class.auto_reloading,
+        }
+
+        model_class.auto_reloading = true
+        model_class.base_path = alternate_base_path
       end
 
-      @cache = nil
-    end
+      def unload_fixtures
+        @cache.each do |model_class, cached_values|
+          model_class.base_path = cached_values[:old_base_path]
+          model_class.load_records
+          model_class.auto_reloading = cached_values[:old_auto_reloading]
+        end
 
-    def self.ensure_model_class_is_frozenrecord(model_class)
-      return if model_class < FrozenRecord::Base
-      raise ArgumentError, "Model class (#{model_class}) does not inherit from #{FrozenRecord::Base}"
+        @cache = nil
+      end
+
+      private
+
+      def ensure_model_class_is_frozenrecord(model_class)
+        return if model_class < FrozenRecord::Base
+        raise ArgumentError, "Model class (#{model_class}) does not inherit from #{FrozenRecord::Base}"
+      end
     end
-    private_class_method :ensure_model_class_is_frozenrecord
   end
 end

--- a/lib/frozen_record/test_helper.rb
+++ b/lib/frozen_record/test_helper.rb
@@ -32,8 +32,6 @@ module FrozenRecord
       @cache = nil
     end
 
-    private
-
     def self.ensure_model_class_is_frozenrecord(model_class)
       return if model_class < FrozenRecord::Base
       raise ArgumentError, "Model class (#{model_class}) does not inherit from #{FrozenRecord::Base}"

--- a/spec/fixtures/test_helper/countries.yml
+++ b/spec/fixtures/test_helper/countries.yml
@@ -1,0 +1,9 @@
+---
+- id: 1
+  name: Some country
+  capital: <%= 'Somewhere' %>
+  density: 1.0
+  population: 42
+  founded_on: 2019-01-01
+  updated_at: 2019-01-01T19:08:06-05:00
+  king: Bob Smith

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
 SimpleCov.start
 
 require 'frozen_record'
+require 'frozen_record/test_helper'
 
 FrozenRecord::Base.base_path = File.join(File.dirname(__FILE__), 'fixtures')
 

--- a/spec/test_helper_spec.rb
+++ b/spec/test_helper_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'test fixture loading' do
+  describe 'by default' do
+    it 'uses the default fixtures' do
+      expect(Country.count).to be == 3
+    end
+  end
+
+  describe '.load_fixture' do
+    it 'uses alternate test fixtures' do
+      test_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures', 'test_helper')
+
+      FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
+      expect(Country.count).to be == 1
+
+      FrozenRecord::TestHelper.unload_fixtures # Note: This is called just to ensure a clean teardown between tests.
+    end
+
+    it 'raises an ArgumentError if the model class does not inherit from FrozenRecord::Base' do
+      expect {
+        some_class = Class.new
+        FrozenRecord::TestHelper.load_fixture(some_class, 'some/path')
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '.unload_fixtures' do
+    it 'restores the default fixtures' do
+      test_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures', 'test_helper')
+
+      FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
+      FrozenRecord::TestHelper.unload_fixtures
+
+      expect(Country.count).to be == 3
+    end
+  end
+end

--- a/spec/test_helper_spec.rb
+++ b/spec/test_helper_spec.rb
@@ -23,6 +23,19 @@ describe 'test fixture loading' do
         FrozenRecord::TestHelper.load_fixture(some_class, 'some/path')
       }.to raise_error(ArgumentError)
     end
+
+    it 'uses test fixtures that were loaded first, and ignores repeat calls to load_fixture' do
+      test_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures', 'test_helper')
+      FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
+      expect(Country.count).to be == 1
+
+      # Note: If we actually loaded this fixture, we'd expect 3 Countries to be loaded. Instead, we continue to get 3.
+      test_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures')
+      FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
+      expect(Country.count).to be == 1
+
+      FrozenRecord::TestHelper.unload_fixtures
+    end
   end
 
   describe '.unload_fixtures' do
@@ -33,12 +46,6 @@ describe 'test fixture loading' do
       FrozenRecord::TestHelper.unload_fixtures
 
       expect(Country.count).to be == 3
-    end
-
-    it 'raises NoFixturesLoaded if load_fixture was never previously called' do
-      expect {
-        FrozenRecord::TestHelper.unload_fixtures
-      }.to raise_error(FrozenRecord::TestHelper::NoFixturesLoaded)
     end
   end
 end

--- a/spec/test_helper_spec.rb
+++ b/spec/test_helper_spec.rb
@@ -34,5 +34,11 @@ describe 'test fixture loading' do
 
       expect(Country.count).to be == 3
     end
+
+    it 'raises NoFixturesLoaded if load_fixture was never previously called' do
+      expect {
+        FrozenRecord::TestHelper.unload_fixtures
+      }.to raise_error(FrozenRecord::TestHelper::NoFixturesLoaded)
+    end
   end
 end


### PR DESCRIPTION
Splitting out a test helper added in https://github.com/Shopify/shopify/pull/185768 to be included in the upstream gem. 

# Usage

```ruby
require 'frozen_record/test_helper'

# During test/spec setup
test_fixtures_base_path = 'alternate/fixture/path'
FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
# Raises ArgumentError if anything but a 

# During test/spec teardown
FrozenRecord::TestHelper.unload_fixtures
```