### PR TITLE
Fix TestHelper.unload_fixtures when run on its own

### DIFF
--- a/lib/frozen_record/test_helper.rb
+++ b/lib/frozen_record/test_helper.rb
@@ -20,6 +20,8 @@ module FrozenRecord
       end
 
       def unload_fixtures
+        return unless @cache
+
         @cache.each do |model_class, cached_values|
           model_class.base_path = cached_values[:old_base_path]
           model_class.load_records

--- a/spec/test_helper_spec.rb
+++ b/spec/test_helper_spec.rb
@@ -47,5 +47,11 @@ describe 'test fixture loading' do
 
       expect(Country.count).to be == 3
     end
+
+    it 'does has no effect if no alternate fixtures were loaded' do
+      FrozenRecord::TestHelper.unload_fixtures
+
+      expect(Country.count).to be == 3
+    end
   end
 end


### PR DESCRIPTION
My last-minute changes to https://github.com/byroot/frozen_record/pull/23 overlooked the scenario in which `unload_fixtures` is called on its own, when `load_fixture` has either never been called prior, or was already called. `@cache` is nil or undefined this situation, so we error out trying to call `.each`.

This PR fixes that problem.