### PR TITLE
add equality operator to compare two scopes

### DIFF
--- a/lib/frozen_record/scope.rb
+++ b/lib/frozen_record/scope.rb
@@ -122,6 +122,15 @@ module FrozenRecord
       array_delegable?(method_name) || @klass.respond_to?(method_name) || super
     end
 
+    def hash
+      to_hashable_string.hash
+    end
+
+    def ==(other)
+      self.class === other &&
+       to_hashable_string == other.to_hashable_string
+    end
+
     protected
 
     def scoping
@@ -229,7 +238,13 @@ module FrozenRecord
       self
     end
 
+    def to_hashable_string
+      "#{@klass} -- WHERE: #{@where_values.uniq.sort}, NOT: #{@where_not_values.uniq.sort}, ORDER_BY: #{@order_values.uniq},
+       LIMIT: #{@limit}, OFFSET: #{@offset}"
+    end
+
     private
+
     def compare_value(actual, requested)
       return actual == requested unless requested.is_a?(Array) || requested.is_a?(Range)
       requested.include?(actual)

--- a/lib/frozen_record/scope.rb
+++ b/lib/frozen_record/scope.rb
@@ -123,15 +123,26 @@ module FrozenRecord
     end
 
     def hash
-      to_hashable_string.hash
+      comparable_attributes.hash
     end
 
     def ==(other)
       self.class === other &&
-       to_hashable_string == other.to_hashable_string
+      comparable_attributes == other.comparable_attributes
     end
 
     protected
+
+    def comparable_attributes
+      @comparable_attributes ||= {
+        klass: @klass,
+        where_values: @where_values.uniq.sort,
+        where_not_values: @where_not_values.uniq.sort,
+        order_values: @order_values.uniq,
+        limit: @limit,
+        offset: @offset,
+      }
+    end
 
     def scoping
       previous, @klass.current_scope = @klass.current_scope, self
@@ -145,6 +156,7 @@ module FrozenRecord
     end
 
     def clear_cache!
+      @comparable_attributes = nil
       @results = nil
       @matches = nil
       self
@@ -236,11 +248,6 @@ module FrozenRecord
     def offset!(amount)
       @offset = amount
       self
-    end
-
-    def to_hashable_string
-      "#{@klass} -- WHERE: #{@where_values.uniq.sort}, NOT: #{@where_not_values.uniq.sort}, ORDER_BY: #{@order_values.uniq},
-       LIMIT: #{@limit}, OFFSET: #{@offset}"
     end
 
     private

--- a/spec/fixtures/countries.yml
+++ b/spec/fixtures/countries.yml
@@ -17,7 +17,9 @@
   population: 65.7
   founded_on: 486-01-01
   updated_at: 2014-02-12T19:02:03-02:00
+  nato: true
   continent: Europe
+
 
 - id: 3
   name: Austria

--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -417,6 +417,23 @@ describe 'querying' do
 
   end
 
+  describe '#==' do
+    it 'returns true when two scopes share the same hashed attributes' do
+      scope_a = Country.republics.nato
+      scope_b = Country.republics.nato
+      expect(scope_a.object_id).not_to be == scope_b.object_id
+      expect(scope_a).to be == scope_b
+    end
+
+    it 'returns true when the same scope has be rechained' do
+      scope_a = Country.nato.republics.nato.republics
+      scope_b = Country.republics.nato
+      expect(scope_a.instance_variable_get(:@where_values)).to be == [[:nato, true ], [:king, nil ], [:nato, true], [:king, nil]]
+      expect(scope_b.instance_variable_get(:@where_values)).to be == [[:king, nil ], [:nato, true]]
+      expect(scope_a).to be == scope_b
+    end
+  end
+
   describe 'class methods delegation' do
 
     it 'can be called from a scope' do

--- a/spec/support/country.rb
+++ b/spec/support/country.rb
@@ -4,6 +4,10 @@ class Country < FrozenRecord::Base
     where(king: nil)
   end
 
+  def self.nato
+    where(nato: true)
+  end
+
   def reverse_name
     name.reverse
   end


### PR DESCRIPTION
This PR adds 2 new public methods and one protected method to allow different instances of Scope to be compared. This addresses the issue we had in this PR https://github.com/Shopify/shopify/pull/211784#issuecomment-521268785 

When two instances of Scope have the same have the same unique and sorted `@where_values` and `@where_not_values` and the same unique (but unsorted) `@order_values`, then they could be considered the same scope. 

I also added `nato: true` to the France fixture just because France is part of NATO 😄 