### PR TITLE
add scope :symbol, lamda syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,12 @@ Country.
 
 ### Scopes
 
-While the `scope :symbol, lambda` syntax is not supported, the class methods way is:
+Basic `scope :symbol, lambda` syntax is now supported in addition to class method syntax.
 
 ```ruby
 class Country
+  scope :european, -> { where(continent: 'Europe' ) }
+
   def self.republics
     where(king: nil)
   end
@@ -108,7 +110,7 @@ class Country
   end
 end
 
-Country.republics.part_of_nato.order(id: :desc)
+Country.european.republics.part_of_nato.order(id: :desc)
 ```
 
 ### Supported query methods
@@ -181,7 +183,7 @@ class CountryTest < ActiveSupport::TestCase
   teardown do
     FrozenRecord::TestHelper.unload_fixtures
   end
-  
+
   test "countries have a valid name" do
   # ...
 ```

--- a/lib/frozen_record/base.rb
+++ b/lib/frozen_record/base.rb
@@ -106,6 +106,13 @@ module FrozenRecord
         end
       end
 
+      def scope(name, body)
+        unless body.respond_to?(:call)
+          raise ArgumentError, "The scope body needs to be callable."
+        end
+        singleton_class.send(:define_method, name) { |*args| body.call(*args) }
+      end
+
       private
 
       def file_changed?

--- a/spec/fixtures/countries.yml
+++ b/spec/fixtures/countries.yml
@@ -8,6 +8,7 @@
   updated_at: 2014-02-24T19:08:06-05:00
   nato: true
   king: Elisabeth II
+  continent: North America
 
 - id: 2
   name: France
@@ -16,6 +17,7 @@
   population: 65.7
   founded_on: 486-01-01
   updated_at: 2014-02-12T19:02:03-02:00
+  continent: Europe
 
 - id: 3
   name: Austria
@@ -24,3 +26,4 @@
   population: 8.462
   founded_on: 1156-01-01
   updated_at: 2014-02-12T19:02:03-02:00
+  continent: Europe

--- a/spec/frozen_record_spec.rb
+++ b/spec/frozen_record_spec.rb
@@ -71,6 +71,15 @@ describe FrozenRecord::Base do
 
   end
 
+  describe '.scope' do
+    it 'defines a scope method' do
+
+      Country.scope :north_american, -> { Country.where(continent: 'North America') }
+      expect(Country).to respond_to(:north_american)
+      expect(Country.north_american.first.name).to be == 'Canada'
+    end
+  end
+
   describe '#load_records' do
 
     it 'processes erb by default' do
@@ -124,6 +133,7 @@ describe FrozenRecord::Base do
         'updated_at' => Time.parse('2014-02-24T19:08:06-05:00'),
         'king' => 'Elisabeth II',
         'nato' => true,
+        'continent' => 'North America',
       }
     end
 


### PR DESCRIPTION
Originally when I tried to fix the issue of comparing scopes, I tried to give scopes a name attribute. To automatically set the name, I ended up using a simplified version of the scope method from https://github.com/rails/rails/blob/master/activerecord/lib/active_record/scoping/named.rb. 

Giving a scope a name didn't work because what happens when you chain them? A big ugly mess is what. I think #27 is a better solution for comparing scopes.  

The simplified scope method still seemed like it might be some nice, so I thought I'd make a PR for that too while I was at it. 

