### PR TITLE
Include JSON backend by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ but this option can be changed per model:
 
 ```ruby
 class Country < FrozenRecord::Base
-  self.backend = FrozenRecord::Backends::Yaml
+  self.backend = FrozenRecord::Backends::Json
 end
 ```
 

--- a/lib/frozen_record/backends.rb
+++ b/lib/frozen_record/backends.rb
@@ -1,0 +1,6 @@
+module FrozenRecord
+  module Backends
+    autoload :Json, 'frozen_record/backends/json'
+    autoload :Yaml, 'frozen_record/backends/yaml'
+  end
+end

--- a/lib/frozen_record/backends/json.rb
+++ b/lib/frozen_record/backends/json.rb
@@ -1,0 +1,16 @@
+module FrozenRecord
+  module Backends
+    module Json
+      extend self
+
+      def filename(model_name)
+        "#{model_name.underscore.pluralize}.json"
+      end
+
+      def load(file_path)
+        json_data = File.read(file_path)
+        JSON.parse(json_data, symbolize_names: true) || []
+      end
+    end
+  end
+end

--- a/lib/frozen_record/base.rb
+++ b/lib/frozen_record/base.rb
@@ -1,5 +1,6 @@
 require 'set'
 require 'active_support/descendants_tracker'
+require 'frozen_record/backends/json'
 require 'frozen_record/backends/yaml'
 
 module FrozenRecord

--- a/lib/frozen_record/base.rb
+++ b/lib/frozen_record/base.rb
@@ -1,7 +1,6 @@
 require 'set'
 require 'active_support/descendants_tracker'
-require 'frozen_record/backends/json'
-require 'frozen_record/backends/yaml'
+require 'frozen_record/backends'
 
 module FrozenRecord
   class Base

--- a/spec/support/animal.rb
+++ b/spec/support/animal.rb
@@ -1,16 +1,3 @@
-module JsonBackend
-  extend self
-
-  def filename(model_name)
-    "#{model_name.underscore.pluralize}.json"
-  end
-
-  def load(file_path)
-    json_data = File.read(file_path)
-    JSON.parse(json_data) || []
-  end
-end
-
 class Animal < FrozenRecord::Base
-  self.backend = JsonBackend
+  self.backend = FrozenRecord::Backends::Json
 end


### PR DESCRIPTION
This builds atop of the work done in https://github.com/byroot/frozen_record/pull/20 and makes it easier to share FrozenRecord data files between backend gems and frontend modules (something I'd like for https://github.com/activemerchant/payment_icons for example) without everyone needing to reimplement the Ruby JSON backend in their app.