### PR TITLE
Add support for attributes that are arrays

### DIFF
--- a/lib/frozen_record/scope.rb
+++ b/lib/frozen_record/scope.rb
@@ -266,8 +266,18 @@ module FrozenRecord
     private
 
     def compare_value(actual, requested)
+      return compare_array(actual, requested) if actual.is_a?(Array)
+      compare_string(actual, requested)
+    end
+
+    def compare_string(actual, requested)
       return actual == requested unless requested.is_a?(Array) || requested.is_a?(Range)
       requested.include?(actual)
+    end
+
+    def compare_array(actual, requested)
+      return actual.include?(requested) unless requested.is_a?(Array) || requested.is_a?(Range)
+      requested.any? { |item| actual.include?(item) }
     end
   end
 end

--- a/spec/fixtures/countries.yml.erb
+++ b/spec/fixtures/countries.yml.erb
@@ -9,6 +9,9 @@
   nato: true
   king: Elisabeth II
   continent: North America
+  official_languages:
+    - English
+    - French
 
 - id: 2
   name: France
@@ -19,6 +22,8 @@
   updated_at: 2014-02-12T19:02:03-02:00
   nato: true
   continent: Europe
+  official_languages:
+    - French
 
 - id: 3
   name: Austria
@@ -29,3 +34,5 @@
   updated_at: 2014-02-12T19:02:03-02:00
   continent: Europe
   available: false
+  official_languages:
+    - German

--- a/spec/frozen_record_spec.rb
+++ b/spec/frozen_record_spec.rb
@@ -156,6 +156,7 @@ RSpec.shared_examples 'main' do
         'continent' => 'North America',
         'available' => true,
         'contemporary' => true,
+        'official_languages' => %w(English French)
       }
     end
 

--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -215,6 +215,17 @@ describe 'querying' do
       countries = Country.where(name: ['France', 'Canada'])
       expect(countries.length).to be == 2
     end
+
+    it 'can be used when attributes are arrays' do
+      countries = Country.where(official_languages: 'French')
+      expect(countries.length).to be == 2
+    end
+
+    it 'can be used when attributes are arrays and search is an array' do
+      countries = Country.where(official_languages: ['French', 'German'])
+      expect(countries.length).to be == 3
+    end
+
   end
 
   describe '.where.not' do


### PR DESCRIPTION
This PR is a feature request to enable FrozenRecord objects to contain attributes that are arrays.

I'm not sure if this was an idea at one point, or if it had already been ruled out, but I came across a use-case where this would of been handy and saved writing some boilerplate code in the model to achieve the same result.

Let me know what you think 😄 