### PR TITLE
Fix Ruby 2.7 kwargs usage in chained scoped methods

### DIFF
--- a/lib/frozen_record/scope.rb
+++ b/lib/frozen_record/scope.rb
@@ -227,6 +227,7 @@ module FrozenRecord
         super
       end
     end
+    ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
 
     def delegate_to_class(*args, &block)
       scoping { @klass.public_send(*args, &block) }

--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -193,6 +193,11 @@ describe 'querying' do
       expect(countries.length).to be == 0
     end
 
+    it 'is chainable with methods of the form `def method(*args, **kargs)' do
+      countries = Country.republics.continent_and_capital('Europe', capital: 'Paris')
+      expect(countries.length).to be == 1
+    end
+
     it 'can be used with arrays' do
       countries = Country.where(id: [1,2])
       expect(countries.length).to be == 2

--- a/spec/support/country.rb
+++ b/spec/support/country.rb
@@ -12,6 +12,10 @@ class Country < FrozenRecord::Base
     where(nato: true)
   end
 
+  def self.continent_and_capital(continent, capital:)
+    where(continent: continent, capital: capital)
+  end
+
   def reverse_name
     name.reverse
   end


### PR DESCRIPTION
Chaining a scope class method with Ruby 2.7+ and keyword args fails without this patch. [Example from Shopify](https://github.com/Shopify/shopify/pull/265075/files#diff-e18916e0bcf75f7ace2a36dbeb598b654b6ea48b19a362f3e99891908af81c49R51). 

@byroot 's original suggestion was to try `ruby2_keywords :delegate_to_class if respond_to?(:ruby2_keywords, true)` for the method below, but I found that I could only get tests to pass (like [this one](https://github.com/Shopify/shopify/pull/265075/files#diff-c16ae735612081f6ae06a57350ad95e2f39f7f467efdcf201f1d15b72ab9eb9bR66)) if I targeted `method_missing` instead. 

