### PR TITLE
Require a minimal subset of ActiveSupport

### DIFF
--- a/lib/frozen_record.rb
+++ b/lib/frozen_record.rb
@@ -2,7 +2,7 @@
 
 require 'yaml'
 require 'set'
-require 'active_support/all'
+require 'active_support/core_ext/hash/keys'
 require 'active_model'
 
 require 'dedup'


### PR DESCRIPTION
This PR replaces `require 'active_support/all'` with the minimal subset of core extensions necessary to keep the tests passing. This allows performance-sensitive consumers to avoid core extensions they don't need.