### PR TITLE
Change exclude? calls to lessen dependency on active_support

### DIFF
--- a/lib/frozen_record/base.rb
+++ b/lib/frozen_record/base.rb
@@ -239,7 +239,7 @@ module FrozenRecord
     private
 
     def attribute?(attribute_name)
-      FALSY_VALUES.exclude?(self[attribute_name]) && self[attribute_name].present?
+      !FALSY_VALUES.include?(self[attribute_name]) && self[attribute_name].present?
     end
 
     def attribute_method?(attribute_name)

--- a/lib/frozen_record/compact.rb
+++ b/lib/frozen_record/compact.rb
@@ -74,7 +74,7 @@ module FrozenRecord
 
     def attribute?(attribute_name)
       val = self[attribute_name]
-      Base::FALSY_VALUES.exclude?(val) && val.present?
+      !Base::FALSY_VALUES.include?(val) && val.present?
     end
   end
 end

--- a/lib/frozen_record/scope.rb
+++ b/lib/frozen_record/scope.rb
@@ -234,7 +234,7 @@ module FrozenRecord
     end
 
     def array_delegable?(method)
-      Array.method_defined?(method) && DISALLOWED_ARRAY_METHODS.exclude?(method)
+      Array.method_defined?(method) && !DISALLOWED_ARRAY_METHODS.include?(method)
     end
 
     def where!(criterias)


### PR DESCRIPTION
Hey, sorry I didn't catch this one earlier.

When we require only `frozen_record/minimal` these calls to `Set#exclude?` fail.  So this PR replaces `exclude?` with `!(...).include?`.

Another approach would be to explicitly require `active_support/core_ext/enumerable`. That would impose that requirement on consumers, but from my reading it's not too heavy of a module. Happy to go either way.