### PR TITLE
Add a dimension of the CI matrix to test frozen_record/minimal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       matrix:
         ruby: [ '2.5', '2.6', '2.7', '3.0' ]
-    name: Ruby ${{ matrix.ruby }} tests
+        minimal: [ false, true ]
+    name: Ruby ${{ matrix.ruby }} tests, minimal=${{ matrix.minimal }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Ruby
@@ -26,4 +27,6 @@ jobs:
           gem install bundler
           bundle install --jobs 4 --retry 3 --path=vendor/bundle
       - name: Run tests
+        env:
+          MINIMAL: ${{ matrix.minimal }}
         run: bundle exec rake

--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -415,7 +415,7 @@ describe 'querying' do
 
   end
 
-  describe '.as_json' do
+  describe '.as_json', exclude_minimal: true do
 
     it 'serialize the results' do
       json = Country.all.as_json

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,13 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
 SimpleCov.start
 
 require 'objspace'
-require 'frozen_record'
+
+if ENV['MINIMAL']
+  require 'frozen_record/minimal'
+else
+  require 'frozen_record'
+end
+
 require 'frozen_record/test_helper'
 
 FrozenRecord::Base.base_path = File.join(File.dirname(__FILE__), 'fixtures')
@@ -23,6 +29,7 @@ FrozenRecord.eager_load!
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
+  config.filter_run_excluding :exclude_minimal if ENV['MINIMAL']
 
   config.order = 'random'
 


### PR DESCRIPTION
This adds a dimension to the CI matrix to run the test suite with only `frozen_record/minimal` required. When testing the minimal configuration, it skips tests tagged with `exclude_minimal`.