### PR TITLE
Check value of MINIMAL env variable because github sets it "false"

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+minimal = ENV['MINIMAL'] == 'true'
+
 require 'pry'
 require 'simplecov'
 require 'coveralls'
@@ -12,7 +14,7 @@ SimpleCov.start
 
 require 'objspace'
 
-if ENV['MINIMAL']
+if minimal
   require 'frozen_record/minimal'
 else
   require 'frozen_record'
@@ -29,7 +31,7 @@ FrozenRecord.eager_load!
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
-  config.filter_run_excluding :exclude_minimal if ENV['MINIMAL']
+  config.filter_run_excluding :exclude_minimal if minimal
 
   config.order = 'random'
 


### PR DESCRIPTION
I should have made https://github.com/byroot/frozen_record/pull/43 a draft PR first, sorry.

Turns out that Github writes booleans to the env as strings, which means the exclude_minimal tests were always excluded.

<img width="384" alt="image" src="https://user-images.githubusercontent.com/4642599/106027144-9b326a00-6098-11eb-8a56-4f841de15efd.png">

Now we check the value rather than just the truthiness.