### PR TITLE
if defined use unsafe_load and unsafe_load_file for YAML backends [support psych >= 4.0]

### DIFF
--- a/lib/frozen_record/backends/yaml.rb
+++ b/lib/frozen_record/backends/yaml.rb
@@ -48,6 +48,11 @@ module FrozenRecord
 
       private
 
+      attr_reader :load_method, :load_file_method
+
+      @load_method = YAML.respond_to?(:unsafe_load) ? :unsafe_load : :load
+      @load_file_method = YAML.respond_to?(:unsafe_load_file) ? :unsafe_load_file : :load_file
+
       supports_freeze = begin
         YAML.load_file(File.expand_path('../empty.json', __FILE__), freeze: true)
       rescue ArgumentError
@@ -56,19 +61,19 @@ module FrozenRecord
 
       if supports_freeze
         def load_file(path)
-          YAML.load_file(path, freeze: true) || Dedup::EMPTY_ARRAY
+          YAML.public_send(load_file_method, path, freeze: true) || Dedup::EMPTY_ARRAY
         end
 
         def load_string(yaml)
-          YAML.load(yaml, freeze: true) || Dedup::EMPTY_ARRAY
+          YAML.public_send(load_method, yaml, freeze: true) || Dedup::EMPTY_ARRAY
         end
       else
         def load_file(path)
-          Dedup.deep_intern!(YAML.load_file(path) || Dedup::EMPTY_ARRAY)
+          Dedup.deep_intern!(YAML.public_send(load_file_method, path) || Dedup::EMPTY_ARRAY)
         end
 
         def load_string(yaml)
-          Dedup.deep_intern!(YAML.load(yaml) || Dedup::EMPTY_ARRAY)
+          Dedup.deep_intern!(YAML.public_send(load_method, yaml) || Dedup::EMPTY_ARRAY)
         end
       end
     end


### PR DESCRIPTION
### What & Why
With 4.0 psych now defaults `YAML.load` to `YAML.safe_load`, which needs you to specify the classes you allow via the permitted_classes option [here](https://github.com/ruby/psych/blob/216f94fb9aacb0754f1dd2257b8d6a61b278a8b2/lib/psych.rb#L322).

Without permitted classes specified, loading Dates of Regexp for example, produces an error:
https://github.com/ruby/psych/issues/496
https://github.com/ruby/psych/issues/489

Similar to what was done with ActiveRecord with [Rails 6.1.4](https://github.com/rails/rails/releases/tag/v6.1.4), should FrozenRecord switch to loading YAML backends using `unsafe_load` to be compatible with psych 4?
I believe the yaml files would be considered "[trusted sources](https://github.com/ruby/psych/issues/489#issuecomment-841354484)", as they are in-repo.


### Reproduction
I have verified on a rails application that includes both `psych` and `frozen_record` as dependencies as follows:

```yaml
# db/data/tracking/carrier.yml
----
- name: Royal Mail
  pattern: !ruby/regexp '/^([A-Z]{2}\d{9}GB)$/i'
  url: "http://www.royalmail.com/portal/rm/track?trackNumber=%s"
```

```ruby
# Gemfile
gem "frozen_record"
gem "psych", "4.0.1"
```

```ruby
# rails console
[1] pry(main)> Tracking::Carrier.first
Psych::DisallowedClass: Tried to load unspecified class: Regexp
from /Users/natmorcos/.gem/ruby/2.7.2/gems/psych-4.0.1/lib/psych/class_loader.rb:99:in `find'
[2] pry(main)>
```

when updating frozen record to point to a local checkout on this branch, it succeeds:

```ruby
[1] pry(main)> Tracking::Carrier
=> Tracking::Carrier
[2] pry(main)> Tracking::Carrier.first
=> #<Tracking::Carrier:0x00007fe9d7684a48
 @attributes={"name"=>"Royal Mail", "pattern"=>/^([A-Z]{2}\d{9}GB)$/i, "url"=>"http://www.royalmail.com/portal/rm/track?trackNumber=%s"}>
```

### Specs
The fixture data already has a case that fails `safe_load` because there are dates:
https://github.com/byroot/frozen_record/blob/91b226837e558cf004f0cac056c908f805972ae4/spec/fixtures/countries.yml.erb#L7-L8

but I couldn't get the tests to run on this repo using `psych >= 4.0.0` without adding either a development dependency or a runtime dependency on `pysch` to the gemspec, which seems wrong. Hoping for a suggestion here 😀  

with the following line added to the gemspec: 
```ruby
spec.add_development_dependency 'psych'
```
the current tests fail without this change and pass with it.