### PR TITLE
Fix README testing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ require 'frozen_record/test_helper'
 
 class CountryTest < ActiveSupport::TestCase
   setup do
-    test_fixtures_base_path = Rails.root.join(%w(test support fixtures))
+    test_fixtures_base_path = Rails.root.join('test/support/fixtures')
     FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
   end
 


### PR DESCRIPTION
👋  Ran into a `no implicit conversion of Array into String` error with the default testing example. Looks like we need to splat the array of strings so we have `join('test', 'support', 'fixtures')` instead of `join(['test', 'support', 'fixtures'])`.

Mild 🎩 🎩 🎩 🎩 🎩 
<img width="793" alt="Screen Shot 2021-07-07 at 19 10 00" src="https://user-images.githubusercontent.com/1557529/124742968-35f07800-df58-11eb-8add-b5f92788adc7.png">

CC @tzyinc