### PR TITLE
Granular fixture unloads

### DIFF
--- a/spec/fixtures/continents.yml.erb
+++ b/spec/fixtures/continents.yml.erb
@@ -1,0 +1,9 @@
+---
+- id: 1
+  name: Africa
+
+- id: 2
+  name: Antarctica
+
+- id: 3
+  name: Asia

--- a/spec/fixtures/test_helper/continents.yml.erb
+++ b/spec/fixtures/test_helper/continents.yml.erb
@@ -1,0 +1,3 @@
+---
+- id: 1
+  name: Some continent

--- a/spec/support/continent.rb
+++ b/spec/support/continent.rb
@@ -1,0 +1,2 @@
+class Continent < FrozenRecord::Base
+end

--- a/spec/test_helper_spec.rb
+++ b/spec/test_helper_spec.rb
@@ -38,19 +38,35 @@ describe 'test fixture loading' do
     end
   end
 
+  describe '.unload_fixture' do
+    it 'restores the default fixtures for the specified model class' do
+      test_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures', 'test_helper')
+
+      FrozenRecord::TestHelper.load_fixture(Continent, test_fixtures_base_path)
+      FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
+      FrozenRecord::TestHelper.unload_fixture(Country)
+
+      expect(Continent.count).to be == 1
+      expect(Country.count).to be == 3
+    end
+  end
+
   describe '.unload_fixtures' do
     it 'restores the default fixtures' do
       test_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures', 'test_helper')
 
+      FrozenRecord::TestHelper.load_fixture(Continent, test_fixtures_base_path)
       FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
       FrozenRecord::TestHelper.unload_fixtures
 
+      expect(Continent.count).to be == 3
       expect(Country.count).to be == 3
     end
 
     it 'does has no effect if no alternate fixtures were loaded' do
       FrozenRecord::TestHelper.unload_fixtures
 
+      expect(Continent.count).to be == 3
       expect(Country.count).to be == 3
     end
   end


### PR DESCRIPTION
This PR introduces the ability to unload fixtures for a specific class.

In our applications' test suites, we've often found ourselves wanting to load one set of general fixtures to back our models for most tests, but then to load several different, more specific fixtures just for each model's unit tests. The inability to unload fixtures for a single class made this very difficult.