### PR TITLE
Only load `Railtie` integration if `Rails::Railtie` is defined

### DIFF
--- a/lib/frozen_record.rb
+++ b/lib/frozen_record.rb
@@ -2,4 +2,4 @@
 
 require 'frozen_record/minimal'
 require 'frozen_record/serialization'
-require 'frozen_record/railtie' if defined?(Rails)
+require 'frozen_record/railtie' if defined?(Rails::Railtie)


### PR DESCRIPTION
As pointed by the [Rails documentation](https://api.rubyonrails.org/classes/Rails/Railtie.html#class-Rails::Railtie-label-Creating+a+Railtie), creating Railties should explicitly ensure that `Rails::Railtie` is defined.

There could be non-rails application use-cases where `Rails` is defined, yet `Rails::Railtie` is not loaded.

I'm not sure how to add a test for this, if you have any idea?