### PR TITLE
`#==` returns `false` if primary key is `nil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- `FrozenRecord::Base#==` now returns `false` if the primary key is `nil` (to match the `ActiveRecord::Base` implementation)
+
 # v0.25.4
 
 - Minor Ruby 3.2 compatiblity fix (regarding `ruby2_keywords`).

--- a/lib/frozen_record/base.rb
+++ b/lib/frozen_record/base.rb
@@ -252,7 +252,7 @@ module FrozenRecord
     alias_method :attribute, :[]
 
     def ==(other)
-      super || other.is_a?(self.class) && other.id == id
+      super || other.is_a?(self.class) && !id.nil? && other.id == id
     end
 
     def persisted?

--- a/spec/frozen_record_spec.rb
+++ b/spec/frozen_record_spec.rb
@@ -149,6 +149,13 @@ RSpec.shared_examples 'main' do
       expect(country).to be == second_country
     end
 
+    it 'returns false if both instances are from the same class and their ids are nil' do
+      country = country_model.new(id: nil)
+      second_country = country_model.new(id: nil)
+
+      expect(country).to_not be == second_country
+    end
+
     it 'returns false if both instances are not from the same class' do
       country = country_model.first
       car = car_model.new(id: country.id)


### PR DESCRIPTION
The implementation in this commit brings `FrozenRecord::Base#==` in
line with [`ActiveRecord::Base#==`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/core.rb#L557).

It fixes a bug where records without IDs would evaluate as equal to
each other. This behaviour was unintuitive and misaligned with the
(better) `ActiveRecord::Base` implementation.