### PR TITLE
Optionally return a new object on find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Implement `clone_on_find` option to return a new object each time a finder method is called.
+
 # v0.26.0
 
 - Drop dependency on `dedup` gem.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ FrozenRecord::Base.auto_reloading = true # Activate reloading for all models
 Country.auto_reloading # Activate reloading for `Country` only
 ```
 
+### Cloning
+
+By default, FrozenRecord objects are instantiated once and then cached indefinitely in memory. Each time a finder method is called, the same cached object is returned. As a result, any state you set on the FrozenRecord object (in instance variables, for example) is shared state and will remain present on that object when it is next returned from a finder method.
+
+This behavior can be unintuitive for users of ActiveRecord, since each time an ActiveRecord finder method is called a new object is instantiated with its own separate state.
+
+If you are storing state on your objects and prefer the ActiveRecord behavior, set `FrozenRecord::Base.clone_on_find = true` to receive a new object each time you call a finder method on that class.
+
 ## Testing
 
 Testing your FrozenRecord-backed models with test fixtures is made easier with:

--- a/lib/frozen_record/base.rb
+++ b/lib/frozen_record/base.rb
@@ -29,6 +29,7 @@ module FrozenRecord
     FALSY_VALUES = [false, nil, 0, -''].to_set
 
     class_attribute :base_path, :primary_key, :backend, :auto_reloading, :default_attributes, instance_accessor: false
+    class_attribute :clone_on_find, instance_accessor: false
     class_attribute :index_definitions, instance_accessor: false
     class_attribute :max_records_scan, instance_accessor: false
     self.index_definitions = {}.freeze
@@ -261,6 +262,10 @@ module FrozenRecord
 
     def to_key
       [id]
+    end
+
+    def clone
+      self.class.new(attributes)
     end
 
     private

--- a/lib/frozen_record/scope.rb
+++ b/lib/frozen_record/scope.rb
@@ -34,7 +34,7 @@ module FrozenRecord
     end
 
     def find_by_id(id)
-      matching_records.find { |r| r.id == id }
+      clone_record(matching_records.find { |r| r.id == id })
     end
 
     def find(id)
@@ -166,7 +166,7 @@ module FrozenRecord
     end
 
     def query_results
-      slice_records(matching_records)
+      clone_records(slice_records(matching_records))
     end
 
     def matching_records
@@ -226,6 +226,15 @@ module FrozenRecord
       first = @offset || 0
       last = first + (@limit || records.length)
       records[first...last] || []
+    end
+
+    def clone_records(records)
+      records.map { |record| clone_record(record) }
+    end
+
+    def clone_record(record)
+      return record unless @klass.clone_on_find
+      record.clone
     end
 
     def compare(record_a, record_b)

--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -500,4 +500,44 @@ describe 'querying' do
     end
 
   end
+
+  context 'when clone_on_find is set' do
+    around(:each) do |example|
+      previous_value = Country.clone_on_find
+      Country.clone_on_find = true
+      example.run
+    ensure
+      Country.clone_on_find = previous_value
+    end
+
+    it 'returns a new object each time find is called' do
+      object_a = Country.find(1)
+      object_a.gdp = 5_000
+
+      object_b = Country.find(1)
+
+      expect(object_a.gdp).to eq(5_000)
+      expect(object_b.gdp).to be_nil
+    end
+  end
+
+  context 'when clone_on_find is not set' do
+    around(:each) do |example|
+      previous_value = Country.clone_on_find
+      Country.clone_on_find = false
+      example.run
+    ensure
+      Country.clone_on_find = previous_value
+    end
+
+    it 'returns the same object each time find is called' do
+      object_a = Country.find(1)
+      object_a.gdp = 5_000
+
+      object_b = Country.find(1)
+
+      expect(object_a.gdp).to eq(5_000)
+      expect(object_b.gdp).to eq(5_000)
+    end
+  end
 end

--- a/spec/support/country.rb
+++ b/spec/support/country.rb
@@ -19,6 +19,8 @@ class Country < FrozenRecord::Base
   def reverse_name
     name.reverse
   end
+
+  attr_accessor :gdp
 end
 
 module Compact


### PR DESCRIPTION
By default, FrozenRecord objects are instantiated once and then cached
indefinitely in memory. Each time a finder method is called, the same
cached object is returned. As a result, any state that's set on the
FrozenRecord object (in instance variables, for example) is shared state
and will remain present on that object when it is next returned from a
finder method.

This behavior can be unintuitive for users of ActiveRecord, since each
time an ActiveRecord finder method is called a new object is
instantiated with its own separate state.

This adds a new option that allows users who are storing state on their
objects and prefer the ActiveRecord behavior to receive a new object
each time they call a finder method.