### PR TITLE
Add Custom Attribute De-serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,31 @@ Composite index keys are not supported.
 
 The primary key isn't indexed by default.
 
+## Serialized fields
+
+The `attribute` method can be used to provide a custom class to deserialize an attribute.  The class must implement a
+`load` class method that takes the raw attribute value and returns the deserialized value (similar to
+[ActiveRecord serialization](https://api.rubyonrails.org/v7.0.4/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize)).
+
+```ruby
+class ContinentString < String
+  class << self
+    alias_method :load, :new
+  end
+end
+
+Size = Struct.new(:length, :width, :depth) do
+  def self.load(value) # value is lxwxd eg: "23x12x5"
+    new(*value.split('x'))
+  end
+end
+
+class Country < FrozenRecord::Base
+  attribute :continent, ContinentString
+  attribute :size, Size
+end
+```
+
 ## Limitations
 
 Frozen Record is not meant to operate on large unindexed datasets.

--- a/lib/frozen_record/compact.rb
+++ b/lib/frozen_record/compact.rb
@@ -13,8 +13,8 @@ module FrozenRecord
 
         @records ||= begin
           records = backend.load(file_path)
-          if default_attributes
-            records = records.map { |r| assign_defaults!(r.dup).freeze }.freeze
+          if attribute_deserializers.any? || default_attributes
+            records = records.map { |r| assign_defaults!(deserialize_attributes!(r.dup)).freeze }.freeze
           end
           @attributes = list_attributes(records).freeze
           build_attributes_cache

--- a/spec/fixtures/countries.yml.erb
+++ b/spec/fixtures/countries.yml.erb
@@ -9,6 +9,7 @@
   nato: true
   king: Elisabeth II
   continent: North America
+  currency_code: CAD
 
 - id: 2
   name: France
@@ -29,3 +30,4 @@
   updated_at: 2014-02-12T19:02:03-02:00
   continent: Europe
   available: false
+  currency_code: EUR

--- a/spec/frozen_record_spec.rb
+++ b/spec/frozen_record_spec.rb
@@ -80,6 +80,41 @@ RSpec.shared_examples 'main' do
 
   end
 
+  describe '.attribute' do
+
+    it 'deserializes the attribute' do
+      expect(country_model.find_by(name: 'Canada').continent).to be_a(TectonicString)
+    end
+
+    it 'sets the default value as default' do
+      expect(country_model.find_by(name: 'France').currency_code).to be == CurrencyCode.load("EUR")
+    end
+
+    it 'returns the first matching record' do
+      country = Country.find_by(currency_code: CurrencyCode.load('EUR'))
+      expect(country.name).to be == 'France'
+    end
+
+    it 'returns nil if record not found' do
+      country = Country.find_by(currency_code: CurrencyCode.load('THB'))
+      expect(country).to be_nil
+    end
+
+    it 'raises if no record found!' do
+      expect {
+        Country.find_by!(currency_code: CurrencyCode.load('THB'))
+      }.to raise_error(FrozenRecord::RecordNotFound)
+    end
+
+    it 'deserializes in the initializer' do
+      expect(country_model.new(currency_code: "CHF").currency_code).to be == CurrencyCode.load('CHF')
+    end
+    
+    it 'also sets the default in the initializer' do
+      expect(country_model.new.currency_code).to be == CurrencyCode.load('EUR')
+    end
+  end
+
   describe '.scope' do
 
     it 'defines a scope method' do
@@ -189,6 +224,7 @@ RSpec.shared_examples 'main' do
         'continent' => 'North America',
         'available' => true,
         'contemporary' => true,
+        'currency_code' => CurrencyCode.load('CAD'),
       }
     end
 

--- a/spec/support/country.rb
+++ b/spec/support/country.rb
@@ -1,8 +1,25 @@
+class CurrencyCode
+  class << self
+    def load(value)
+      value.to_sym
+    end
+  end
+end
+
+class TectonicString < String
+  class << self
+    alias_method :load, :new
+  end
+end
+
 class Country < FrozenRecord::Base
-  self.default_attributes = { contemporary: true, available: true }
+  self.default_attributes = { contemporary: true, available: true, currency_code: CurrencyCode.load('EUR') }
 
   add_index :name, unique: true
   add_index :continent
+
+  attribute :currency_code, CurrencyCode
+  attribute :continent, TectonicString
 
   def self.republics
     where(king: nil)


### PR DESCRIPTION
This PR  adds an `attribute` method for providing a custom attribute deserialization class

The `attribute` method takes a field name and a class.  The class must provide a `load` class method that takes 
the attribute value from the file and returns a deserialized version.  ([Similar to ActiveRecord's serialize](https://api.rubyonrails.org/v7.0.4/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize))

Deserialization is performed in the code close to where default field values are set, as this seemed like a roughly similar operation to me.

This change removes the need to manually serialize and deserialize, for example, Sorbet T::Enums, when using FrozenRecords

```ruby
class AnimalEnum < T::Enum
  def self.load(value)
    try_deserialize(value)
  end

  enums do
    Dog = new('dog')
    Cat = new('cat')
    Bird = new('bird')
  end
end
```

```ruby
class Price < Object
  attr :value

  class << self
    alias_method :load, :new
  end
  def initialize(value)
    @value = value
  end
end
```

```ruby
class PetLicenseFees < FrozenRecord::Base
  self.base_path = '.'

  attribute :fee, Price
  attribute :animal, AnimalEnum
end
```

```yaml
---
- id: 1
  animal: dog
  fee: 3.50

- id: 2
  animal: cat
  fee: 4.00
```


```ruby
puts (PetLicenseFees.first.attributes)
puts (PetLicenseFees.last.attributes)
```

```
{"id"=>1, "animal"=>#<AnimalEnum::Dog>, "fee"=>#<Price:0x00007fef051b5070 @value=3.5>}
{"id"=>2, "animal"=>#<AnimalEnum::Cat>, "fee"=>#<Price:0x00007fef051ba520 @value=4.0>}
```