### PR TITLE
Handle gracefully fixtures that only exist for tests in `TestHelper.unload_fixture`

### DIFF
--- a/lib/frozen_record/test_helper.rb
+++ b/lib/frozen_record/test_helper.rb
@@ -47,7 +47,7 @@ module FrozenRecord
       # As `unload_fixture(s)` tries to force load the default file, it would raise an error for
       # the "test only" fixtures. The nil value in the cache handles that case gracefully.
       def base_path_if_file_present(model_class)
-        if File.exists?(model_class.file_path)
+        if File.exist?(model_class.file_path)
           model_class.base_path
         else
           nil

--- a/spec/fixtures/test_helper/only_in_tests.yml.erb
+++ b/spec/fixtures/test_helper/only_in_tests.yml.erb
@@ -1,0 +1,3 @@
+---
+- id: 1
+  name: Some continent

--- a/spec/test_helper_spec.rb
+++ b/spec/test_helper_spec.rb
@@ -49,6 +49,18 @@ describe 'test fixture loading' do
       expect(Continent.count).to be == 1
       expect(Country.count).to be == 3
     end
+
+    context "when the test fixture does not exist in normal base path" do
+      class OnlyInTest < FrozenRecord::Base; end
+      before do
+        test_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures', 'test_helper')
+        FrozenRecord::TestHelper.load_fixture(OnlyInTest, test_fixtures_base_path)
+      end
+      it 'unload fixture gracefully recovers from an ' do
+
+        expect { FrozenRecord::TestHelper.unload_fixture(OnlyInTest) }.not_to raise_error
+      end
+    end
   end
 
   describe '.unload_fixtures' do


### PR DESCRIPTION
# Description

When using the test helper with fixtures that only exist under their name in tests, then `unload_fixture` was bailing as it tried to force load those model classes from their "original" path.

# What approach

Just rescue from any StandardError (load records throws Errno::ENOENT) on `load_records` in the `unload_fixture` implementation. 

# What else was considered

Leaving all test frozenrecords with names that also exist in the normal path and splitting them by different path names.
That was a bit unwieldy to have so many directories names like tests which all contained the same file name.

# Questions 
- Is their another way to do that and not blowing up the path structure for multiple fixtures?
- Should we log maybe?
- Should I catch the ` Errno::ENOENT` specifically?
