### PR TITLE
Allow load_fixture to switch fixture path for already-loaded models

### DIFF
--- a/lib/frozen_record/test_helper.rb
+++ b/lib/frozen_record/test_helper.rb
@@ -10,7 +10,10 @@ module FrozenRecord
 
         ensure_model_class_is_frozenrecord(model_class)
 
-        return if @cache.key?(model_class)
+        if @cache.key?(model_class)
+          return if model_class.base_path.to_s == alternate_base_path.to_s
+          unload_fixture(model_class)
+        end
 
         @cache[model_class] = base_path_if_file_present(model_class)
 

--- a/spec/test_helper_spec.rb
+++ b/spec/test_helper_spec.rb
@@ -24,17 +24,41 @@ describe 'test fixture loading' do
       }.to raise_error(ArgumentError)
     end
 
-    it 'uses test fixtures that were loaded first, and ignores repeat calls to load_fixture' do
+    it 'is a no-op when called again with the same path' do
       test_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures', 'test_helper')
       FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
       expect(Country.count).to be == 1
 
-      # Note: If we actually loaded this fixture, we'd expect 3 Countries to be loaded. Instead, we continue to get 3.
-      test_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures')
       FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
       expect(Country.count).to be == 1
 
       FrozenRecord::TestHelper.unload_fixtures
+    end
+
+    it 'switches to the new fixtures when called with a different path' do
+      test_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures', 'test_helper')
+      FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
+      expect(Country.count).to be == 1
+
+      default_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures')
+      FrozenRecord::TestHelper.load_fixture(Country, default_fixtures_base_path)
+      expect(Country.count).to be == 3
+
+      FrozenRecord::TestHelper.unload_fixtures
+    end
+
+    it 'preserves the original base_path for unload after switching paths' do
+      original_base_path = Country.base_path
+
+      test_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures', 'test_helper')
+      FrozenRecord::TestHelper.load_fixture(Country, test_fixtures_base_path)
+
+      default_fixtures_base_path = File.join(File.dirname(__FILE__), 'fixtures')
+      FrozenRecord::TestHelper.load_fixture(Country, default_fixtures_base_path)
+
+      FrozenRecord::TestHelper.unload_fixtures
+      expect(Country.base_path).to eq(original_base_path)
+      expect(Country.count).to be == 3
     end
   end
 


### PR DESCRIPTION
## Summary

- `TestHelper.load_fixture` now unloads and reloads when called for an already-cached model with a **different** `alternate_base_path`. Previously, the second call was silently ignored regardless of path, leaving stale data from the first load.
- Calls with the **same** path remain a no-op (preserving the existing optimization).

## Problem

When two different test setups call `load_fixture` for the same model class but with different fixture paths, the second call is silently skipped because the cache only checks `@cache.key?(model_class)` — it doesn't compare paths:

```ruby
# Test A's setup:
FrozenRecord::TestHelper.load_fixture(ApiChange, "test/fixtures/webhooks")  # loads 27 records

# Test B's setup (different path, same model):
FrozenRecord::TestHelper.load_fixture(ApiChange, "test/fixtures/versioning")  # silently ignored — still 27 webhook records
```

This is a footgun in test suites where execution order is randomized and different test groups use different fixture directories for the same FrozenRecord model.

## Fix

When `load_fixture` is called for a model already in the cache, compare the currently loaded `base_path` against the requested `alternate_base_path`. If they match, return early (no-op). If they differ, call `unload_fixture` first to restore the original `base_path`, then proceed with the new load. The original `base_path` (for `unload_fixtures` teardown) is preserved correctly because `unload_fixture` restores it before the re-load captures a new snapshot.

## Tests

- Updated the existing "ignores repeat calls" test to specifically assert same-path no-op behavior
- Added test: switching to a different path loads the new fixture data
- Added test: `unload_fixtures` still restores the original `base_path` after path switches